### PR TITLE
Related-Bug: #1462880

### DIFF
--- a/connect-redis_1.4.5_3.patch
+++ b/connect-redis_1.4.5_3.patch
@@ -1,0 +1,11 @@
+--- node_modules/connect-redis/node_modules/redis/index.js	2015-07-02 15:02:33.000000000 +0530
++++ node_modules/connect-redis/node_modules/redis/index.js	2015-07-02 15:03:23.000000000 +0530
+@@ -6,7 +6,7 @@
+     to_array = require("./lib/to_array"),
+     events = require("events"),
+     crypto = require("crypto"),
+-    contrailConfig = require(process.mainModule.exports['corePath'] + '/config/config.global'),
++    contrailConfig = process.mainModule.exports["config"],
+     parsers = [], commands,
+     connection_id = 0,
+     default_port = 6379,

--- a/kue_0.5.0_2.patch
+++ b/kue_0.5.0_2.patch
@@ -1,0 +1,11 @@
+--- node_modules/kue/node_modules/redis/index.js	2015-07-02 15:05:53.000000000 +0530
++++ node_modules/kue/node_modules/redis/index.js	2015-07-02 15:06:19.000000000 +0530
+@@ -5,7 +5,7 @@
+     Queue = require("./lib/queue"),
+     to_array = require("./lib/to_array"),
+     events = require("events"),
+-    contrailConfig = require(process.mainModule.exports['corePath'] + '/config/config.global'),
++    contrailConfig = process.mainModule.exports["config"],
+     parsers = [], commands,
+     connection_id = 0,
+     default_port = 6379,

--- a/packages.xml
+++ b/packages.xml
@@ -356,6 +356,7 @@
     <md5>6c477fc7937376eda70ffe3740f28def</md5>
     <patches>
       <patch strip="0">kue_0.5.0_1.patch</patch>
+      <patch strip="0">kue_0.5.0_2.patch</patch>
     </patches>
   </package>
   <package>
@@ -371,6 +372,7 @@
     <md5>18245e4b52467384d44a6c7faf6a12b5</md5>
     <patches>
       <patch strip="0">redis_0.8.3_1.patch</patch>
+      <patch strip="0">redis_0.8.3_2.patch</patch>
     </patches>
   </package>
   <package>
@@ -444,6 +446,7 @@
     <patches>
       <patch strip="2">connect-redis_1.4.5.patch</patch>
       <patch strip="0">connect-redis_1.4.5_2.patch</patch>
+      <patch strip="0">connect-redis_1.4.5_3.patch</patch>
     </patches>
   </package>
   <package>

--- a/redis_0.8.3_2.patch
+++ b/redis_0.8.3_2.patch
@@ -1,0 +1,11 @@
+--- node_modules/redis/index.js	2015-07-02 15:10:16.000000000 +0530
++++ node_modules/redis/index.js	2015-07-02 15:10:58.000000000 +0530
+@@ -6,7 +6,7 @@
+     to_array = require("./lib/to_array"),
+     events = require("events"),
+     crypto = require("crypto"),
+-    contrailConfig = require(process.mainModule.exports['corePath'] + '/config/config.global'),
++    contrailConfig = process.mainModule.exports["config"],
+     parsers = [], commands,
+     connection_id = 0,
+     default_port = 6379,


### PR DESCRIPTION
In stead of taking config from config/config.global.js, use the exported config
which is the merged version of config/config.global.js and
default.config.global.js

Change-Id: I0367e233c81f3e74c082b489520decf9c3827ef1