### PR TITLE
Partial-Bug: #1520382, #1520675

### DIFF
--- a/packages.xml
+++ b/packages.xml
@@ -250,9 +250,6 @@
     <format>tgz</format>
     <md5>4f4880148fd1222f85f605bbbc4e4e57</md5>
     <rename>nvd3-v1.8.1</rename>
-    <patches>
-      <patch strip="2">nvd3-v1.8.1.patch</patch>
-    </patches>
   </package>
   <package>
     <name>knockout-3.0.0</name>


### PR DESCRIPTION
Optimize the initial loading of webui after login

- Remove qe-utils, d3-utils, topology_api, nvd3-plugin from initial version
- Remove the old version of nvd3. Remove path from nvd3 v 1.8.1, use the minified file for nvd3 and d3
- Cleanup requires definitions and dependencies

Fix issues in broken test-cases

- Fix broken project or instance test-cases

Change-Id: I98e33459c972a5c274d01238f12c531c9c7f831f