### PR TITLE
Related-Bug: #1526930, Partial-Bug: #1532686

### DIFF
--- a/packages.xml
+++ b/packages.xml
@@ -501,6 +501,12 @@
     <rename>requirejs-v1.0.2</rename>
   </package>
   <package>
+    <name>requirejs</name>
+    <url>https://github.com/Juniper/contrail-third-party-cache/raw/master/contrail-webui/common/npm-sources/requirejs-2.1.20.tar.gz</url>
+    <format>npm-cached</format>
+    <md5>5e2121931b2a5730fc5887535fdad1b6</md5>
+  </package>
+  <package>
     <name>underscore-v1.6.0</name>
     <url>https://github.com/Juniper/contrail-third-party-cache/raw/master/contrail-webui/server-manager/underscore-min.js</url>
     <local-filename>underscore-min.js</local-filename>

--- a/packages_dev.xml
+++ b/packages_dev.xml
@@ -90,12 +90,6 @@
     <md5>d6c1a9f42484e7d4e13b0d8b5b33c5a4</md5>
   </package>
   <package>
-    <name>requirejs</name>
-    <url>https://github.com/Juniper/contrail-third-party-cache/raw/master/contrail-webui/common/npm-sources/requirejs-2.1.20.tar.gz</url>
-    <format>npm-cached</format>
-    <md5>5e2121931b2a5730fc5887535fdad1b6</md5>
-  </package>
-  <package>
     <name>karma-requirejs</name>
     <url>https://github.com/Juniper/contrail-third-party-cache/raw/master/contrail-webui/common/npm-sources/karma-requirejs-0.2.2.tar.gz</url>
     <format>npm-cached</format>


### PR DESCRIPTION
- production enviroment now builds the js files using r.js.
making the requirejs library part of main env, instead only in dev-env

Change-Id: I06aae0ad3e461e2375f9376941616546a999457c