### PR TITLE
Closes-Bug #1575922 Enabling passing arguments for npm install

### DIFF
--- a/fetch_packages.py
+++ b/fetch_packages.py
@@ -107,6 +107,7 @@ def ProcessPackage(pkg):
     url = str(pkg['url'])
     filename = getFilename(pkg, url)
     ccfile = _PACKAGE_CACHE + '/' + filename
+    installArguments = pkg.find('install-arguments')
     if pkg.format == 'npm-cached':
         try:
             shutil.rmtree(str(_NODE_MODULES + '/' + pkg['name']))
@@ -174,6 +175,8 @@ def ProcessPackage(pkg):
         cmd = ['unzip', '-o', ccfile]
     elif pkg.format == 'npm':
         cmd = ['npm', 'install', ccfile, '--prefix', _PACKAGE_CACHE]
+        if installArguments:
+            cmd.append(str(installArguments))
     elif pkg.format == 'file':
         cmd = ['cp', '-af', ccfile, dest]
     elif pkg.format == 'npm-cached':
@@ -181,6 +184,8 @@ def ProcessPackage(pkg):
     else:
         print 'Unexpected format: %s' % (pkg.format)
         return
+
+    print 'Issuing command: %s' % (cmd)
 
     if not _OPT_DRY_RUN:
         cd = None

--- a/packages_dev.xml
+++ b/packages_dev.xml
@@ -33,6 +33,7 @@
     <name>phantomjs</name>
     <url>https://github.com/Juniper/contrail-third-party-cache/raw/master/contrail-webui/common/phantomjs-1.9.18.tar.gz</url>
     <format>npm</format>
+    <install-arguments>--phantomjs_cdnurl=https://github.com/Juniper/contrail-third-party-cache/raw/master/contrail-webui/common/phantomjs-bin</install-arguments>
     <md5>898f5c9feb3797b78d555b433bacaa13</md5>
   </package>
   <package>


### PR DESCRIPTION
Related-Bug #1569510

- added fetch_packages script to support <install-arguments> tag from xml
- updated phantomJS cdn url to contrail third party cache.

Change-Id: I146583485665d807d812d3a20d75d66dacd49119