### PR TITLE
Related-Bug: #1617070 - Library Upgrades

### DIFF
--- a/packages.xml
+++ b/packages.xml
@@ -61,13 +61,6 @@
     <md5>0e390e86b02e36b6240ef27c01b63a4b</md5>
   </package>
   <package>
-    <name>jquery.ba-bbq.min</name>
-    <url>https://github.com/Juniper/contrail-third-party-cache/raw/master/contrail-webui/controller/jquery.ba-bbq.min-v1.3pre.js</url>
-    <local-filename>jquery.ba-bbq.min.js</local-filename>
-    <format>file</format>
-    <md5>856cc20a1756ca55dc9f13eecf5b1b2d</md5>
-  </package>
-  <package>
     <name>jquery.timer</name>
     <url>https://github.com/Juniper/contrail-third-party-cache/raw/master/contrail-webui/controller/jquery.timer.js</url>
     <local-filename>jquery.timer.js</local-filename>
@@ -235,12 +228,28 @@
     <md5>104d5d1d77adfc68cf2b08fb37c237a7</md5>
   </package>
   <package>
+    <name>knockout-3.4.0</name>
+    <url>https://github.com/Juniper/contrail-third-party-cache/raw/master/contrail-webui/controller/knockout-3.4.0.tar.gz</url>
+    <local-filename>knockout-3.4.0.tar.gz</local-filename>
+    <format>tgz</format>
+    <md5>921f633a813c3f1fcd30ae1131a706bd</md5>
+    <rename>knockout-3.4.0</rename>
+  </package>
+  <package>
     <name>jquery-validation-1.11.1</name>
     <url>https://github.com/Juniper/contrail-third-party-cache/raw/master/contrail-webui/controller/jquery-validation-1.11.1.tar.gz</url>
     <local-filename>jquery-validation-1.11.1.tar.gz</local-filename>
     <format>tgz</format>
     <md5>83596ed1ef7982e06cb5690ad6f103f4</md5>
     <rename>jquery-validation-v1.11.1</rename>
+  </package>
+  <package>
+    <name>jquery-validation-1.15.1</name>
+    <url>https://github.com/Juniper/contrail-third-party-cache/raw/master/contrail-webui/controller/jquery-validation-1.15.1.tar.gz</url>
+    <local-filename>jquery-validation-1.15.1.tar.gz</local-filename>
+    <format>tgz</format>
+    <md5>628ac3d3e49b4e4f78e157dc06730640</md5>
+    <rename>jquery-validation-v1.15.1</rename>
   </package>
   <package>
     <name>select2-3.4.6</name>
@@ -274,6 +283,14 @@
     <rename>moment-v2.6.0</rename>
   </package>
   <package>
+    <name>moment-2.14.1</name>
+    <url>https://github.com/Juniper/contrail-third-party-cache/raw/master/contrail-webui/controller/moment-2.14.1.tar.gz</url>
+    <local-filename>moment-2.14.1.tar.gz</local-filename>
+    <format>tgz</format>
+    <md5>cb156d513bc237a3ed644f67216a1c65</md5>
+    <rename>moment-v2.14.1</rename>
+  </package>
+  <package>
     <name>knockout-v3.0.0</name>
     <url>https://github.com/Juniper/contrail-third-party-cache/raw/master/contrail-webui/controller/knockout-v3.0.0.tar.gz</url>
     <local-filename>knockout-v3.0.0.tar.gz</local-filename>
@@ -287,6 +304,13 @@
     <local-filename>handlebars-v1.3.0.js</local-filename>
     <format>file</format>
     <md5>d7a58c286b230beb275041d8718e6d64</md5>
+  </package>
+  <package>
+    <name>handlebars-v4.0.5</name>
+    <url>https://github.com/Juniper/contrail-third-party-cache/raw/master/contrail-webui/controller/handlebars-v4.0.5.js</url>
+    <local-filename>handlebars-v4.0.5.js</local-filename>
+    <format>file</format>
+    <md5>443b6dfae4afa132f7d9f31fc5f20742</md5>
   </package>
   <package>
     <name>SlickGridEnhancementPager</name>
@@ -482,6 +506,13 @@
     <md5>d6b42423bafb425248aa6277ca16d8c2</md5>
   </package>
   <package>
+    <name>backbone-v1.3.3</name>
+    <url>https://github.com/Juniper/contrail-third-party-cache/raw/master/contrail-webui/controller/backbone-1.3.3.tar.gz</url>
+    <local-filename>backbone-1.3.3.tar.gz</local-filename>
+    <format>tgz</format>
+    <md5>2dd8afe808f8a5dc95da7bcb4736ff16</md5>
+  </package>
+  <package>
     <name>requirejs</name>
     <url>https://github.com/Juniper/contrail-third-party-cache/raw/master/contrail-webui/server-manager/requirejs-1.0.2.tar.gz</url>
     <local-filename>requirejs-1.0.2.tar.gz</local-filename>
@@ -510,6 +541,13 @@
     <md5>ba0d413ebe08a9248aaa1588aca34267</md5>
   </package>
   <package>
+    <name>underscore-v1.8.3</name>
+    <url>https://github.com/Juniper/contrail-third-party-cache/raw/master/contrail-webui/controller/underscore-1.8.3.tar.gz</url>
+    <local-filename>underscore-1.8.3.tar.gz</local-filename>
+    <format>tgz</format>
+    <md5>9f9936c1cb657b63b472e915c6d47cc7</md5>
+  </package>
+  <package>
     <name>jquery.multiselect-v1.15</name>
     <url>https://github.com/Juniper/contrail-third-party-cache/raw/master/contrail-webui/controller/jquery-ui-multiselect-widget-1.15.tar.gz</url>
     <local-filename>jquery-ui-multiselect-widget-1.15.tar.gz</local-filename>
@@ -522,6 +560,14 @@
     <local-filename>knockback.min.js</local-filename>
     <format>file</format>
     <md5>f7f2fad534fc7ff0c7ea8992bd602ff5</md5>
+  </package>
+  <package>
+    <name>knockback-1.1.0</name>
+    <url>https://github.com/Juniper/contrail-third-party-cache/raw/master/contrail-webui/controller/knockback-1.1.0.tar.gz</url>
+    <local-filename>knockback-1.1.0.tar.gz</local-filename>
+    <format>tgz</format>
+    <md5>47e28fb41981c4515af0f6caf363381e</md5>
+    <rename>knockback-1.1.0</rename>
   </package>
   <package>
     <name>jquery-steps-v1.1.0</name>
@@ -574,6 +620,14 @@
     <format>tgz</format>
     <md5>f68f04f3df4cdd0b65c17d489f20e6ac</md5>
     <rename>jquery.panzoom-v2.0.5</rename>
+  </package>
+  <package>
+    <name>PanZoom-3.2.1</name>
+    <url>https://github.com/Juniper/contrail-third-party-cache/raw/master/contrail-webui/controller/jquery.panzoom-3.2.1.tar.gz</url>
+    <local-filename>jquery.panzoom-v3.2.1.tar.gz</local-filename>
+    <format>tgz</format>
+    <md5>eea51f49bf1f456156505016dee46459</md5>
+    <rename>jquery.panzoom-v3.2.1</rename>
   </package>
   <package>
     <name>ipv6</name>
@@ -698,13 +752,13 @@
   </package>
   <package>
     <name>node-sass</name>
-    <url>https://github.com/Juniper/contrail-third-party-cache/raw/master/contrail-webui/controller/node-sass-3.8.0.tar.gz</url>
+    <url>https://github.com/Juniper/contrail-third-party-cache/raw/master/contrail-webui/common/npm-sources/node-sass-3.8.0.tar.gz</url>
     <format>npm</format>
     <md5>2c4de27b5b9322395a7e249d5b11265c</md5>
   </package>
   <package>
     <name>bootstrap-sass</name>
-    <url>https://github.com/Juniper/contrail-third-party-cache/raw/master/contrail-webui/controller/bootstrap-sass-3.3.6.tar.gz</url>
+    <url>https://github.com/Juniper/contrail-third-party-cache/raw/master/contrail-webui/common/npm-sources/bootstrap-sass-3.3.6.tar.gz</url>
     <format>npm</format>
     <md5>146ba506a45c1a79872649eee142a1c4</md5>
   </package>


### PR DESCRIPTION
- Upgrade to Knockout 3.4.0
- Upgrade to Backbone 1.3.3
- Upgrade to Knockback 1.1.0
- Upgrade to jquery-validation 1.15.1
- Upgrade to jquery.panzoom 3.2.1
- Upgrade to moment 2.14.1
- Upgrade to Handlebars 4.0.5
- Upgrade to Underscore 1.8.3
- Moving bootstrap-sass and node-sass to contrail-webui/common/npm-sources

Change-Id: I684285e0403c25db5e6d39a51b560c99921747c1